### PR TITLE
Fix Ren'Py displayable and flowchart imports

### DIFF
--- a/game/flowchart.rpy
+++ b/game/flowchart.rpy
@@ -1,9 +1,11 @@
 init python:
     import math
     from collections import defaultdict
+    from renpy import store
     from renpy.display import im
-    from renpy.display.behavior import Function
-    import renpy
+    from renpy.display.core import Displayable
+    from renpy.display.render import Render
+    from renpy.exports import call_in_new_context, hide_screen, jump
 
     FLOWCHART_VIEW_WIDTH = 2000
     FLOWCHART_VIEW_HEIGHT = 8200
@@ -115,9 +117,9 @@ init python:
         FLOWCHART_NEIGHBORS[start].append(end)
         FLOWCHART_NEIGHBORS[end].append(start)
 
-    class FlowchartEdges(renpy.Displayable):
+    class FlowchartEdges(Displayable):
         def __init__(self, nodes, edges, width, height, line_color="#cfd7ff", arrow_color="#5c6ed8", line_width=6):
-            super(FlowchartEdges, self).__init__()
+            super().__init__()
             self.nodes = nodes
             self.edges = edges
             self.width = width
@@ -127,8 +129,8 @@ init python:
             self.line_width = line_width
 
         def render(self, width, height, st, at):
-            render = renpy.Render(self.width, self.height)
-            canvas = render.canvas()
+            edge_render = Render(self.width, self.height)
+            canvas = edge_render.canvas()
             for start_id, end_id in self.edges:
                 start_node = self.nodes[start_id]
                 end_node = self.nodes[end_id]
@@ -151,18 +153,18 @@ init python:
                 left = (px - uy * arrow_width / 2.0, py + ux * arrow_width / 2.0)
                 right = (px + uy * arrow_width / 2.0, py - ux * arrow_width / 2.0)
                 canvas.polygon(self.arrow_color, [(ex, ey), left, right])
-            return render
+            return edge_render
 
     def flowchart_jump(node_id, from_main_menu):
         node = FLOWCHART_LOOKUP.get(node_id)
         if not node or not node.get("label"):
             return
-        renpy.store._flowchart_selected = node_id
-        renpy.hide_screen("flowchart")
+        store._flowchart_selected = node_id
+        hide_screen("flowchart")
         if from_main_menu:
-            renpy.call_in_new_context(node["label"])
+            call_in_new_context(node["label"])
         else:
-            renpy.jump(node["label"])
+            jump(node["label"])
 
 screen flowchart():
     tag menu
@@ -205,8 +207,10 @@ screen flowchart():
                             action SetScreenVariable("selected_node", node_id)
                             if not node.get("label"):
                                 sensitive False
-                            add Solid("#ffffff22") if node_id == selected_node else Null()
-                            add Solid("#ffffff11") if hovered_node == node_id and node_id != selected_node else Null()
+                            if node_id == selected_node:
+                                add Solid("#ffffff22")
+                            if hovered_node == node_id and node_id != selected_node:
+                                add Solid("#ffffff11")
                             vbox:
                                 style "flowchart_node_content"
                                 text node["title"] style "flowchart_node_title"

--- a/game/minigames/pong.rpy
+++ b/game/minigames/pong.rpy
@@ -1,7 +1,12 @@
 init python:
-    class PongDisplayable(renpy.Displayable):
+    from renpy.audio import sound
+    from renpy.display.core import Displayable, IgnoreEvent
+    from renpy.display.render import Render, render as render_displayable
+    from renpy.exports import redraw, restart_interaction, timeout
+
+    class PongDisplayable(Displayable):
         def __init__(self):
-            renpy.Displayable.__init__(self)
+            super().__init__()
 
             #游戏参数
             self.PADDLE_WIDTH = 22
@@ -34,7 +39,7 @@ init python:
             return [self.paddle, self.ball]
 
         def render(self, width, height, st, at):
-            r = renpy.Render(width, height)
+            r = Render(width, height)
 
             if self.oldst is None:
                 self.oldst = st
@@ -64,18 +69,18 @@ init python:
                 self.by = ball_top + (ball_top - self.by)
                 self.bdy = -self.bdy
                 if not self.stuck:
-                    renpy.sound.play("pong_beep.opus", channel=0)
+                    sound.play("pong_beep.opus", channel=0)
 
             ball_bot = self.COURT_BOTTOM - self.BALL_HEIGHT / 2
             if self.by > ball_bot:
                 self.by = ball_bot - (self.by - ball_bot)
                 self.bdy = -self.bdy
                 if not self.stuck:
-                    renpy.sound.play("pong_beep.opus", channel=0)
+                    sound.play("pong_beep.opus", channel=0)
 
             #球拍渲染和碰撞
             def paddle(px, py, hotside):
-                pi = renpy.render(self.paddle, width, height, st, at)
+                pi = render_displayable(self.paddle, width, height, st, at)
                 r.blit(pi, (int(px), int(py - self.PADDLE_HEIGHT / 2)))
 
                 if py - self.PADDLE_HEIGHT / 2 <= self.by <= py + self.PADDLE_HEIGHT / 2:
@@ -89,32 +94,32 @@ init python:
                         self.bdx = -self.bdx
                         hit = True
                     if hit:
-                        renpy.sound.play("pong_boop.opus", channel=1)
+                        sound.play("pong_boop.opus", channel=1)
                         self.bspeed *= 1.10
 
             paddle(self.PADDLE_X, self.playery, self.PADDLE_X + self.PADDLE_WIDTH)
             paddle(width - self.PADDLE_X - self.PADDLE_WIDTH, self.computery, width - self.PADDLE_X - self.PADDLE_WIDTH)
 
             #?
-            ball = renpy.render(self.ball, width, height, st, at)
+            ball = render_displayable(self.ball, width, height, st, at)
             r.blit(ball, (int(self.bx - self.BALL_WIDTH / 2), int(self.by - self.BALL_HEIGHT / 2)))
 
             #结束
             if self.bx < -75:
                 self.winner = "computer"
-                renpy.timeout(0)
+                timeout(0)
             elif self.bx > width + 75:
                 self.winner = "player"
-                renpy.timeout(0)
+                timeout(0)
 
-            renpy.redraw(self, 0)
+            redraw(self, 0)
             return r
 
         def event(self, ev, x, y, st):
             import pygame
             if ev.type == pygame.MOUSEBUTTONDOWN and ev.button == 1:
                 self.stuck = False
-                renpy.restart_interaction()
+                restart_interaction()
 
             y = max(y, self.COURT_TOP)
             y = min(y, self.COURT_BOTTOM)
@@ -122,7 +127,7 @@ init python:
 
             if self.winner:
                 return self.winner
-            raise renpy.IgnoreEvent()
+            raise IgnoreEvent()
 
 screen pong():
     default pong = PongDisplayable()


### PR DESCRIPTION
## Summary
- replace the flowchart custom displayable base class and API calls with supported Ren'Py module imports
- update the flowchart screen highlight logic to avoid inline conditional displayables
- rewrite the pong minigame displayable to use explicit Ren'Py audio, render, and interaction helpers instead of the deprecated `renpy` module

## Testing
- not run (Ren'Py runtime not available in the container)


------
https://chatgpt.com/codex/tasks/task_e_68d49b7fdc708331b6bb55a2efc609e4