### PR TITLE
Update fonts to use Noto family with emoji fallback

### DIFF
--- a/game/gui.rpy
+++ b/game/gui.rpy
@@ -56,13 +56,22 @@ define gui.interface_text_color = '#404040'
 ## 字体和字体大小 #####################################################################
 
 ## 游戏内文本使用的字体。
-define gui.text_font = "SourceHanSansLite.ttf"
+define gui.text_font = gui.FontGroup(
+    "NotoSerifSC-VF.ttf",
+    "NotoEmoji-Regular.ttf",
+)
 
 ## 角色名称使用的字体。
-define gui.name_text_font = "SourceHanSansLite.ttf"
+define gui.name_text_font = gui.FontGroup(
+    "NotoSerifSC-VF.ttf",
+    "NotoEmoji-Regular.ttf",
+)
 
 ## 游戏外文本使用的字体。
-define gui.interface_text_font = "SourceHanSansLite.ttf"
+define gui.interface_text_font = gui.FontGroup(
+    "NotoSerifSC-VF.ttf",
+    "NotoEmoji-Regular.ttf",
+)
 
 ## 普通对话文本的大小。
 define gui.text_size = 33

--- a/game/tl/None/common.rpym
+++ b/game/tl/None/common.rpym
@@ -1533,4 +1533,7 @@ translate None strings:
     old "unescape: Disables escaping of unicode symbols in unicode strings and print it as is (default)."
     new "unescape：禁止转义 Unicode 字符串中的 Unicode 符号，并按原样打印（默认）。"
 
-define gui.system_font = 'SourceHanSansLite.ttf'
+define gui.system_font = gui.FontGroup(
+    "NotoSerifSC-VF.ttf",
+    "NotoEmoji-Regular.ttf",
+)


### PR DESCRIPTION
## Summary
- switch GUI text, name, and interface fonts to a Noto Serif + Noto Emoji font group to ensure emoji coverage
- update the system font override to match the new font group for consistent fallback behavior

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d4a5debab083319aacf00289b478c8