### PR TITLE
Enable flowchart access globally and fix layout scroll behavior

### DIFF
--- a/game/flowchart/flowchart.rpy
+++ b/game/flowchart/flowchart.rpy
@@ -8,7 +8,7 @@ init -3:
     default endings = []
     default story_flags = {}
 
-    default flowchart_accessible = False
+    default flowchart_accessible = True
 
 
 init python:
@@ -87,15 +87,16 @@ screen flowchart():
 
     $ current_segment = segment if segment in nodes else next(iter(nodes.keys()))
 
-    use game_menu(_("流程图"), scroll="viewport"):
+    use game_menu(_("流程图")):
         vbox:
             align (0.5, 0.0)
             spacing 30
 
             viewport:
                 xalign 0.5
-                xysize (1625, 7925)
-                child_size (1600, 7900)
+                xsize 1380
+                ysize 600
+                child_size (1380, 7900)
                 mousewheel True
                 scrollbars "vertical"
                 edgescroll (150, 2000)
@@ -120,6 +121,7 @@ screen flowchart():
             frame:
                 style_prefix "flowchart_panel"
                 xalign 0.5
+                xsize 1380
 
                 vbox:
                     spacing 12

--- a/game/screens.rpy
+++ b/game/screens.rpy
@@ -245,6 +245,8 @@ screen quick_menu():
             textbutton _("自动") action Preference("auto-forward", "toggle")
             textbutton _("保存") action ShowMenu('save')
             textbutton _("读取") action ShowMenu('load')
+            if flowchart_accessible:
+                textbutton _("流程图") action ShowMenu('flowchart')
             textbutton _("快存") action QuickSave()
             textbutton _("快读") action QuickLoad()
             textbutton _("设置") action ShowMenu('preferences')


### PR DESCRIPTION
## Summary
- make the flowchart menu available at all times, including through the quick menu
- adjust the flowchart screen viewport so the jump panel stays visible and only the chart scrolls

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d61e184a548331b8ffd4bfc2e2d7e0