### PR TITLE
Add compatibility layer for Ren'Py 8.4 API changes

### DIFF
--- a/game/renpy_compat.rpy
+++ b/game/renpy_compat.rpy
@@ -1,0 +1,31 @@
+"""Ren'Py compatibility helpers for newer engine versions."""
+
+init -999 python:
+    import renpy
+
+    # Some Ren'Py releases move public helpers into the ``renpy.exports``
+    # module. Fall back to that module when an attribute is no longer exported
+    # at the top level so existing scripts keep working across versions.
+    _renpy_exports = getattr(renpy, "exports", None)
+    if _renpy_exports is None:
+        try:
+            from renpy import exports as _renpy_exports
+        except Exception:
+            _renpy_exports = None
+
+    def _copy_from_exports(attr_name):
+        if _renpy_exports and hasattr(_renpy_exports, attr_name) and not hasattr(renpy, attr_name):
+            setattr(renpy, attr_name, getattr(_renpy_exports, attr_name))
+
+    # Restore helpers that were available in older Ren'Py versions.
+    _copy_from_exports("get_side_image")
+    _copy_from_exports("list_files")
+
+    if not hasattr(renpy, "list_files"):
+        loader = getattr(renpy, "loader", None)
+        if loader and hasattr(loader, "listdirfiles"):
+            def _compat_list_files():
+                for entry in loader.listdirfiles():
+                    yield entry
+
+            renpy.list_files = _compat_list_files


### PR DESCRIPTION
## Summary
- add an early-init compatibility script that restores `renpy.list_files` and `renpy.get_side_image` when newer Ren'Py builds stop exporting them

## Testing
- not run (Ren'Py runtime not available in CI)


------
https://chatgpt.com/codex/tasks/task_e_68d62e4ff9e083319a062c8baaf2a3e4